### PR TITLE
Post-second-debate suggestions and suchlike

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -13,7 +13,6 @@
 
                 checklist.list = [
                     'Donald Trump mentions his wealth or smarts',
-                    'Benghazi is mentioned',
                     '"This president..." is uttered',
                     'A candidate whines about not getting called on enough',
                     '"take America back"',
@@ -24,7 +23,10 @@
                     'A candidate talks about "stopping Hillary Clinton."',
                     'Anyone warns the U.S. is becoming Greece.',
                     'Trump refers to himself in the third person.',
-                    'Anyone invokes St. Ronald Reagan.'
+                    'Anyone invokes St. Ronald Reagan.',
+                    'Anyone proposes invading Russia',
+                    'Anyone proposes invading Iran',
+                    'Anyone proposes invading Syria',
                 ];
 
                 // Maps string to boolean value
@@ -88,17 +90,18 @@
                 everytime.phrases = [
                     'I\'m not a scientist',
                     'You can keep your doctor',
-                    'ACORN',
                     'The war on Christians (or Christmas, if that\'s your fancy)',
                     'Thug',
                     'Right here in California',
+                    'A candidate replies with "Wrong"',
                     'Culture of dependency'
                 ];
 
                 everytime.shots = [
                     'Kenya',
                     'All Lives Matter',
-                    'Binders full of women'
+                    'Binders full of women',
+                    'Benghazi'
                 ];
 
                 // maps action string to integer count

--- a/js/index.js
+++ b/js/index.js
@@ -23,7 +23,6 @@
                     'A candidate talks about "stopping Hillary Clinton."',
                     'Anyone warns the U.S. is becoming Greece.',
                     'Trump refers to himself in the third person.',
-                    'Anyone invokes St. Ronald Reagan.',
                     'Anyone proposes invading Russia',
                     'Anyone proposes invading Iran',
                     'Anyone proposes invading Syria',
@@ -85,14 +84,15 @@
                     'Claims a positive relationship with a minority, including "Some of my best friends are..."',
                     'Tries to habla Español',
                     'Awkwardly mentions wildfires'.
+                    'Invokes St. Ronald Reagan.',
                     'Advocates the use of nuclear weapons'
                 ];
 
                 everytime.phrases = [
                     'I\'m not a scientist',
-                    'You can keep your doctor',
+                    'Repealing Obamacare',
                     'The war on Christians (or Christmas, if that\'s your fancy)',
-                    'Thug',
+                    'Thugs and gangsters, but not terrorists',
                     'Right here in <insert state of debate>',
                     'A candidate replies with "Wrong"',
                     'Culture of dependency'

--- a/js/index.js
+++ b/js/index.js
@@ -103,7 +103,8 @@
                     'Kenya',
                     'All Lives Matter',
                     'Binders full of women',
-                    'Benghazi'
+                    '"Obama doesn\'t have" followed by anything',
+                    'Hillary Clinton\'s emails'
                 ];
 
                 // maps action string to integer count

--- a/js/index.js
+++ b/js/index.js
@@ -95,7 +95,8 @@
                     'Thugs and gangsters, but not terrorists',
                     'Right here in <insert state of debate>',
                     'A candidate replies with "Wrong"',
-                    'Culture of dependency'
+                    'Culture of dependency',
+                    '"Gateway drug"'
                 ];
 
                 everytime.shots = [

--- a/js/index.js
+++ b/js/index.js
@@ -84,7 +84,8 @@
                 everytime.actions = [
                     'Claims a positive relationship with a minority, including "Some of my best friends are..."',
                     'Tries to habla Español',
-                    'Awkwardly mentions wildfires'
+                    'Awkwardly mentions wildfires'.
+                    'Advocates the use of nuclear weapons'
                 ];
 
                 everytime.phrases = [
@@ -92,7 +93,7 @@
                     'You can keep your doctor',
                     'The war on Christians (or Christmas, if that\'s your fancy)',
                     'Thug',
-                    'Right here in California',
+                    'Right here in <insert state of debate>',
                     'A candidate replies with "Wrong"',
                     'Culture of dependency'
                 ];


### PR DESCRIPTION
PR's blocked because of merge conflicts, but here's some more suggestions.

Using the old rules, the score for the second debate was 14 drinks and 0 shots. This tries to safely up that.